### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.DOCKER_REGISTRY }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -27,3 +27,4 @@ Automatic Update - 20210106T020036.779Z
 Automatic Update - 20210115T020046.369Z
 Automatic Update - 20210209T020028.096Z
 Automatic Update - 20210219T020024.817Z
+Automatic Update - 20210223T020026.940Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -31,3 +31,4 @@ Automatic Update - 20210223T020026.940Z
 Automatic Update - 20210603T021735.571Z
 Automatic Update - 20210809T020034.880Z
 Automatic Update - 20210829T020035.482Z
+Automatic Update - 20210916T020034.567Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -19,3 +19,4 @@ Automatic Update - 20200903T020028.070Z
 Automatic Update - 20200918T020024.726Z
 Automatic Update - 20201022T020034.636Z
 Automatic Update - 20201028T020022.352Z
+Automatic Update - 20201110T020037.103Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -51,3 +51,4 @@ Automatic Update - 20220624T020307.119Z
 Automatic Update - 20220630T020309.315Z
 Automatic Update - 20220707T020241.503Z
 Automatic Update - 20220710T020309.572Z
+Automatic Update - 20220721T021254.582Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -70,3 +70,4 @@ Automatic Update - 20230131T020344.173Z
 Automatic Update - 20230214T020357.076Z
 Automatic Update - 20230306T020325.363Z
 Automatic Update - 20230310T020248.042Z
+Automatic Update - 20230319T020230.857Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -39,3 +39,4 @@ Automatic Update - 20220311T201747.115Z
 Automatic Update - 20220318T020258.340Z
 Automatic Update - 20220403T020235.397Z
 Automatic Update - 20220415T020248.228Z
+Automatic Update - 20220422T020243.847Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -7,3 +7,4 @@ Automatic Update - 20200507T020021.197Z
 Automatic Update - 20200515T020022.686Z
 Automatic Update - 20200529T020032.921Z
 Automatic Update - 20200610T020031.102Z
+Automatic Update - 20200611T020032.806Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -46,3 +46,4 @@ Automatic Update - 20220513T020311.840Z
 Automatic Update - 20220518T020307.604Z
 Automatic Update - 20220529T020308.527Z
 Automatic Update - 20220602T020243.290Z
+Automatic Update - 20220609T020255.591Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -29,3 +29,4 @@ Automatic Update - 20210209T020028.096Z
 Automatic Update - 20210219T020024.817Z
 Automatic Update - 20210223T020026.940Z
 Automatic Update - 20210603T021735.571Z
+Automatic Update - 20210809T020034.880Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -63,3 +63,4 @@ Automatic Update - 20221113T020305.256Z
 Automatic Update - 20221121T020313.909Z
 Automatic Update - 20221125T020327.558Z
 Automatic Update - 20221130T020324.769Z
+Automatic Update - 20221211T020337.571Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -6,3 +6,4 @@ Automatic Update - 20200428T020021.468Z
 Automatic Update - 20200507T020021.197Z
 Automatic Update - 20200515T020022.686Z
 Automatic Update - 20200529T020032.921Z
+Automatic Update - 20200610T020031.102Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -8,3 +8,4 @@ Automatic Update - 20200515T020022.686Z
 Automatic Update - 20200529T020032.921Z
 Automatic Update - 20200610T020031.102Z
 Automatic Update - 20200611T020032.806Z
+Automatic Update - 20200617T020034.235Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -54,3 +54,4 @@ Automatic Update - 20220710T020309.572Z
 Automatic Update - 20220721T021254.582Z
 Automatic Update - 20220807T020458.877Z
 Automatic Update - 20220908T020301.248Z
+Automatic Update - 20220918T020255.095Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -17,3 +17,4 @@ Automatic Update - 20200820T020027.795Z
 Automatic Update - 20200828T020024.602Z
 Automatic Update - 20200903T020028.070Z
 Automatic Update - 20200918T020024.726Z
+Automatic Update - 20201022T020034.636Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -59,3 +59,4 @@ Automatic Update - 20220925T020256.426Z
 Automatic Update - 20221014T020311.581Z
 Automatic Update - 20221020T020315.000Z
 Automatic Update - 20221029T020305.986Z
+Automatic Update - 20221113T020305.256Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -69,3 +69,4 @@ Automatic Update - 20230114T020353.638Z
 Automatic Update - 20230131T020344.173Z
 Automatic Update - 20230214T020357.076Z
 Automatic Update - 20230306T020325.363Z
+Automatic Update - 20230310T020248.042Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -53,3 +53,4 @@ Automatic Update - 20220707T020241.503Z
 Automatic Update - 20220710T020309.572Z
 Automatic Update - 20220721T021254.582Z
 Automatic Update - 20220807T020458.877Z
+Automatic Update - 20220908T020301.248Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -34,3 +34,4 @@ Automatic Update - 20210829T020035.482Z
 Automatic Update - 20210916T020034.567Z
 Automatic Update - 20210917T020032.976Z
 Automatic Update - 20211202T020031.153Z
+Automatic Update - 20211218T020028.598Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -2,3 +2,4 @@ Automatic Patches
 
 Automatic Update - 20200327T162731.541Z
 Automatic Update - 20200424T020016.553Z
+Automatic Update - 20200428T020021.468Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -65,3 +65,4 @@ Automatic Update - 20221125T020327.558Z
 Automatic Update - 20221130T020324.769Z
 Automatic Update - 20221211T020337.571Z
 Automatic Update - 20230107T020332.033Z
+Automatic Update - 20230114T020353.638Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -41,3 +41,4 @@ Automatic Update - 20220403T020235.397Z
 Automatic Update - 20220415T020248.228Z
 Automatic Update - 20220422T020243.847Z
 Automatic Update - 20220429T020248.736Z
+Automatic Update - 20220506T020249.647Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -4,3 +4,4 @@ Automatic Update - 20200327T162731.541Z
 Automatic Update - 20200424T020016.553Z
 Automatic Update - 20200428T020021.468Z
 Automatic Update - 20200507T020021.197Z
+Automatic Update - 20200515T020022.686Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -12,3 +12,4 @@ Automatic Update - 20200617T020034.235Z
 Automatic Update - 20200625T020017.416Z
 Automatic Update - 20200707T020029.725Z
 Automatic Update - 20200806T020024.101Z
+Automatic Update - 20200811T020022.797Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -16,3 +16,4 @@ Automatic Update - 20200811T020022.797Z
 Automatic Update - 20200820T020027.795Z
 Automatic Update - 20200828T020024.602Z
 Automatic Update - 20200903T020028.070Z
+Automatic Update - 20200918T020024.726Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -26,3 +26,4 @@ Automatic Update - 20201211T025157.970Z
 Automatic Update - 20210106T020036.779Z
 Automatic Update - 20210115T020046.369Z
 Automatic Update - 20210209T020028.096Z
+Automatic Update - 20210219T020024.817Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -24,3 +24,4 @@ Automatic Update - 20201118T020021.902Z
 Automatic Update - 20201209T020022.449Z
 Automatic Update - 20201211T025157.970Z
 Automatic Update - 20210106T020036.779Z
+Automatic Update - 20210115T020046.369Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -60,3 +60,4 @@ Automatic Update - 20221014T020311.581Z
 Automatic Update - 20221020T020315.000Z
 Automatic Update - 20221029T020305.986Z
 Automatic Update - 20221113T020305.256Z
+Automatic Update - 20221121T020313.909Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -22,3 +22,4 @@ Automatic Update - 20201028T020022.352Z
 Automatic Update - 20201110T020037.103Z
 Automatic Update - 20201118T020021.902Z
 Automatic Update - 20201209T020022.449Z
+Automatic Update - 20201211T025157.970Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -36,3 +36,4 @@ Automatic Update - 20210917T020032.976Z
 Automatic Update - 20211202T020031.153Z
 Automatic Update - 20211218T020028.598Z
 Automatic Update - 20220311T201747.115Z
+Automatic Update - 20220318T020258.340Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -13,3 +13,4 @@ Automatic Update - 20200625T020017.416Z
 Automatic Update - 20200707T020029.725Z
 Automatic Update - 20200806T020024.101Z
 Automatic Update - 20200811T020022.797Z
+Automatic Update - 20200820T020027.795Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -23,3 +23,4 @@ Automatic Update - 20201110T020037.103Z
 Automatic Update - 20201118T020021.902Z
 Automatic Update - 20201209T020022.449Z
 Automatic Update - 20201211T025157.970Z
+Automatic Update - 20210106T020036.779Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -62,3 +62,4 @@ Automatic Update - 20221029T020305.986Z
 Automatic Update - 20221113T020305.256Z
 Automatic Update - 20221121T020313.909Z
 Automatic Update - 20221125T020327.558Z
+Automatic Update - 20221130T020324.769Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -1,1 +1,3 @@
 Automatic Patches
+
+Automatic Update - 20200327T162731.541Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -71,3 +71,4 @@ Automatic Update - 20230214T020357.076Z
 Automatic Update - 20230306T020325.363Z
 Automatic Update - 20230310T020248.042Z
 Automatic Update - 20230319T020230.857Z
+Automatic Update - 20230322T020236.213Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -47,3 +47,4 @@ Automatic Update - 20220518T020307.604Z
 Automatic Update - 20220529T020308.527Z
 Automatic Update - 20220602T020243.290Z
 Automatic Update - 20220609T020255.591Z
+Automatic Update - 20220624T020307.119Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -1,3 +1,4 @@
 Automatic Patches
 
 Automatic Update - 20200327T162731.541Z
+Automatic Update - 20200424T020016.553Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -18,3 +18,4 @@ Automatic Update - 20200828T020024.602Z
 Automatic Update - 20200903T020028.070Z
 Automatic Update - 20200918T020024.726Z
 Automatic Update - 20201022T020034.636Z
+Automatic Update - 20201028T020022.352Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -35,3 +35,4 @@ Automatic Update - 20210916T020034.567Z
 Automatic Update - 20210917T020032.976Z
 Automatic Update - 20211202T020031.153Z
 Automatic Update - 20211218T020028.598Z
+Automatic Update - 20220311T201747.115Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -38,3 +38,4 @@ Automatic Update - 20211218T020028.598Z
 Automatic Update - 20220311T201747.115Z
 Automatic Update - 20220318T020258.340Z
 Automatic Update - 20220403T020235.397Z
+Automatic Update - 20220415T020248.228Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -57,3 +57,4 @@ Automatic Update - 20220908T020301.248Z
 Automatic Update - 20220918T020255.095Z
 Automatic Update - 20220925T020256.426Z
 Automatic Update - 20221014T020311.581Z
+Automatic Update - 20221020T020315.000Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -40,3 +40,4 @@ Automatic Update - 20220318T020258.340Z
 Automatic Update - 20220403T020235.397Z
 Automatic Update - 20220415T020248.228Z
 Automatic Update - 20220422T020243.847Z
+Automatic Update - 20220429T020248.736Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -56,3 +56,4 @@ Automatic Update - 20220807T020458.877Z
 Automatic Update - 20220908T020301.248Z
 Automatic Update - 20220918T020255.095Z
 Automatic Update - 20220925T020256.426Z
+Automatic Update - 20221014T020311.581Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -45,3 +45,4 @@ Automatic Update - 20220506T020249.647Z
 Automatic Update - 20220513T020311.840Z
 Automatic Update - 20220518T020307.604Z
 Automatic Update - 20220529T020308.527Z
+Automatic Update - 20220602T020243.290Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -33,3 +33,4 @@ Automatic Update - 20210809T020034.880Z
 Automatic Update - 20210829T020035.482Z
 Automatic Update - 20210916T020034.567Z
 Automatic Update - 20210917T020032.976Z
+Automatic Update - 20211202T020031.153Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -11,3 +11,4 @@ Automatic Update - 20200611T020032.806Z
 Automatic Update - 20200617T020034.235Z
 Automatic Update - 20200625T020017.416Z
 Automatic Update - 20200707T020029.725Z
+Automatic Update - 20200806T020024.101Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -64,3 +64,4 @@ Automatic Update - 20221121T020313.909Z
 Automatic Update - 20221125T020327.558Z
 Automatic Update - 20221130T020324.769Z
 Automatic Update - 20221211T020337.571Z
+Automatic Update - 20230107T020332.033Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -15,3 +15,4 @@ Automatic Update - 20200806T020024.101Z
 Automatic Update - 20200811T020022.797Z
 Automatic Update - 20200820T020027.795Z
 Automatic Update - 20200828T020024.602Z
+Automatic Update - 20200903T020028.070Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -55,3 +55,4 @@ Automatic Update - 20220721T021254.582Z
 Automatic Update - 20220807T020458.877Z
 Automatic Update - 20220908T020301.248Z
 Automatic Update - 20220918T020255.095Z
+Automatic Update - 20220925T020256.426Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -44,3 +44,4 @@ Automatic Update - 20220429T020248.736Z
 Automatic Update - 20220506T020249.647Z
 Automatic Update - 20220513T020311.840Z
 Automatic Update - 20220518T020307.604Z
+Automatic Update - 20220529T020308.527Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -28,3 +28,4 @@ Automatic Update - 20210115T020046.369Z
 Automatic Update - 20210209T020028.096Z
 Automatic Update - 20210219T020024.817Z
 Automatic Update - 20210223T020026.940Z
+Automatic Update - 20210603T021735.571Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -58,3 +58,4 @@ Automatic Update - 20220918T020255.095Z
 Automatic Update - 20220925T020256.426Z
 Automatic Update - 20221014T020311.581Z
 Automatic Update - 20221020T020315.000Z
+Automatic Update - 20221029T020305.986Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -32,3 +32,4 @@ Automatic Update - 20210603T021735.571Z
 Automatic Update - 20210809T020034.880Z
 Automatic Update - 20210829T020035.482Z
 Automatic Update - 20210916T020034.567Z
+Automatic Update - 20210917T020032.976Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -42,3 +42,4 @@ Automatic Update - 20220415T020248.228Z
 Automatic Update - 20220422T020243.847Z
 Automatic Update - 20220429T020248.736Z
 Automatic Update - 20220506T020249.647Z
+Automatic Update - 20220513T020311.840Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -25,3 +25,4 @@ Automatic Update - 20201209T020022.449Z
 Automatic Update - 20201211T025157.970Z
 Automatic Update - 20210106T020036.779Z
 Automatic Update - 20210115T020046.369Z
+Automatic Update - 20210209T020028.096Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -50,3 +50,4 @@ Automatic Update - 20220609T020255.591Z
 Automatic Update - 20220624T020307.119Z
 Automatic Update - 20220630T020309.315Z
 Automatic Update - 20220707T020241.503Z
+Automatic Update - 20220710T020309.572Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -14,3 +14,4 @@ Automatic Update - 20200707T020029.725Z
 Automatic Update - 20200806T020024.101Z
 Automatic Update - 20200811T020022.797Z
 Automatic Update - 20200820T020027.795Z
+Automatic Update - 20200828T020024.602Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -48,3 +48,4 @@ Automatic Update - 20220529T020308.527Z
 Automatic Update - 20220602T020243.290Z
 Automatic Update - 20220609T020255.591Z
 Automatic Update - 20220624T020307.119Z
+Automatic Update - 20220630T020309.315Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -3,3 +3,4 @@ Automatic Patches
 Automatic Update - 20200327T162731.541Z
 Automatic Update - 20200424T020016.553Z
 Automatic Update - 20200428T020021.468Z
+Automatic Update - 20200507T020021.197Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -49,3 +49,4 @@ Automatic Update - 20220602T020243.290Z
 Automatic Update - 20220609T020255.591Z
 Automatic Update - 20220624T020307.119Z
 Automatic Update - 20220630T020309.315Z
+Automatic Update - 20220707T020241.503Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -30,3 +30,4 @@ Automatic Update - 20210219T020024.817Z
 Automatic Update - 20210223T020026.940Z
 Automatic Update - 20210603T021735.571Z
 Automatic Update - 20210809T020034.880Z
+Automatic Update - 20210829T020035.482Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -43,3 +43,4 @@ Automatic Update - 20220422T020243.847Z
 Automatic Update - 20220429T020248.736Z
 Automatic Update - 20220506T020249.647Z
 Automatic Update - 20220513T020311.840Z
+Automatic Update - 20220518T020307.604Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -61,3 +61,4 @@ Automatic Update - 20221020T020315.000Z
 Automatic Update - 20221029T020305.986Z
 Automatic Update - 20221113T020305.256Z
 Automatic Update - 20221121T020313.909Z
+Automatic Update - 20221125T020327.558Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -52,3 +52,4 @@ Automatic Update - 20220630T020309.315Z
 Automatic Update - 20220707T020241.503Z
 Automatic Update - 20220710T020309.572Z
 Automatic Update - 20220721T021254.582Z
+Automatic Update - 20220807T020458.877Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -20,3 +20,4 @@ Automatic Update - 20200918T020024.726Z
 Automatic Update - 20201022T020034.636Z
 Automatic Update - 20201028T020022.352Z
 Automatic Update - 20201110T020037.103Z
+Automatic Update - 20201118T020021.902Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -68,3 +68,4 @@ Automatic Update - 20230107T020332.033Z
 Automatic Update - 20230114T020353.638Z
 Automatic Update - 20230131T020344.173Z
 Automatic Update - 20230214T020357.076Z
+Automatic Update - 20230306T020325.363Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -21,3 +21,4 @@ Automatic Update - 20201022T020034.636Z
 Automatic Update - 20201028T020022.352Z
 Automatic Update - 20201110T020037.103Z
 Automatic Update - 20201118T020021.902Z
+Automatic Update - 20201209T020022.449Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -5,3 +5,4 @@ Automatic Update - 20200424T020016.553Z
 Automatic Update - 20200428T020021.468Z
 Automatic Update - 20200507T020021.197Z
 Automatic Update - 20200515T020022.686Z
+Automatic Update - 20200529T020032.921Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -66,3 +66,4 @@ Automatic Update - 20221130T020324.769Z
 Automatic Update - 20221211T020337.571Z
 Automatic Update - 20230107T020332.033Z
 Automatic Update - 20230114T020353.638Z
+Automatic Update - 20230131T020344.173Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -67,3 +67,4 @@ Automatic Update - 20221211T020337.571Z
 Automatic Update - 20230107T020332.033Z
 Automatic Update - 20230114T020353.638Z
 Automatic Update - 20230131T020344.173Z
+Automatic Update - 20230214T020357.076Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -37,3 +37,4 @@ Automatic Update - 20211202T020031.153Z
 Automatic Update - 20211218T020028.598Z
 Automatic Update - 20220311T201747.115Z
 Automatic Update - 20220318T020258.340Z
+Automatic Update - 20220403T020235.397Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -9,3 +9,4 @@ Automatic Update - 20200529T020032.921Z
 Automatic Update - 20200610T020031.102Z
 Automatic Update - 20200611T020032.806Z
 Automatic Update - 20200617T020034.235Z
+Automatic Update - 20200625T020017.416Z

--- a/patchlog.txt
+++ b/patchlog.txt
@@ -10,3 +10,4 @@ Automatic Update - 20200610T020031.102Z
 Automatic Update - 20200611T020032.806Z
 Automatic Update - 20200617T020034.235Z
 Automatic Update - 20200625T020017.416Z
+Automatic Update - 20200707T020029.725Z

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 MAINTAINER Tremolo Security, Inc. - Docker <docker@tremolosecurity.com>
 
 ENV JDK_VERSION=1.8.0 \
-    OPENUNISON_VERSION="1.0.17.1"
+    OPENUNISON_VERSION="1.0.20"
 
 LABEL io.k8s.description="Job to clear dead letter queues" \
       io.k8s.display-name="OpenUnison Dead Letter Queue Clearer" 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 MAINTAINER Tremolo Security, Inc. - Docker <docker@tremolosecurity.com>
 
 ENV JDK_VERSION=1.8.0 \
-    OPENUNISON_VERSION="1.0.20"
+    OPENUNISON_VERSION="1.0.21"
 
 LABEL io.k8s.description="Job to clear dead letter queues" \
       io.k8s.display-name="OpenUnison Dead Letter Queue Clearer" 
@@ -12,7 +12,7 @@ RUN apt-get update;apt-get -y install curl openjdk-8-jdk-headless ;apt-get -y up
     mkdir -p /usr/local/openunison && \
     groupadd -r openunison -g 433 && \
     useradd -u 431 -r -g openunison -d /usr/local/openunison -s /sbin/nologin -c "OpenUnison Docker image user" openunison && \
-    curl https://nexus.tremolo.io/repository/releases/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
+    curl https://nexus.tremolo.io/repository/betas/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
     chown -R openunison:openunison /usr/local/openunison 
 
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update;apt-get -y install curl openjdk-11-jdk-headless ;apt-get -y u
     mkdir -p /usr/local/openunison && \
     groupadd -r openunison -g 433 && \
     useradd -u 431 -r -g openunison -d /usr/local/openunison -s /sbin/nologin -c "OpenUnison Docker image user" openunison && \
-    curl https://nexus.tremolo.io/repository/betas/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
+    curl https://nexus.tremolo.io/repository/releases/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
     chown -R openunison:openunison /usr/local/openunison 
 
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-MAINTAINER Tremolo Security, Inc. - Docker <docker@tremolosecurity.com>
+MAINTAINER Tremolo Security, Inc.  - Docker <docker@tremolosecurity.com>
 
 ENV JDK_VERSION=1.8.0 \
     OPENUNISON_VERSION="1.0.21"

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update;apt-get -y install curl openjdk-8-jdk-headless ;apt-get -y up
     mkdir -p /usr/local/openunison && \
     groupadd -r openunison -g 433 && \
     useradd -u 431 -r -g openunison -d /usr/local/openunison -s /sbin/nologin -c "OpenUnison Docker image user" openunison && \
-    curl https://nexus.tremolo.io/repository/betas/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
+    curl https://nexus.tremolo.io/repository/releases/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
     chown -R openunison:openunison /usr/local/openunison 
 
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER Tremolo Security, Inc.  - Docker <docker@tremolosecurity.com>
 
-ENV JDK_VERSION=1.8.0 \
+ENV JDK_VERSION=1.11.0 \
     OPENUNISON_VERSION="1.0.30"
 
 LABEL io.k8s.description="Job to clear dead letter queues" \
       io.k8s.display-name="OpenUnison Dead Letter Queue Clearer" 
 
-RUN apt-get update;apt-get -y install curl openjdk-8-jdk-headless ;apt-get -y upgrade;apt-get clean;rm -rf /var/lib/apt/lists/*; \ 
+RUN apt-get update;apt-get -y install curl openjdk-11-jdk-headless ;apt-get -y upgrade;apt-get clean;rm -rf /var/lib/apt/lists/*; \ 
     mkdir -p /usr/local/openunison && \
     groupadd -r openunison -g 433 && \
     useradd -u 431 -r -g openunison -d /usr/local/openunison -s /sbin/nologin -c "OpenUnison Docker image user" openunison && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 MAINTAINER Tremolo Security, Inc.  - Docker <docker@tremolosecurity.com>
 
 ENV JDK_VERSION=1.11.0 \
-    OPENUNISON_VERSION="1.0.30"
+    OPENUNISON_VERSION="1.0.31"
 
 LABEL io.k8s.description="Job to clear dead letter queues" \
       io.k8s.display-name="OpenUnison Dead Letter Queue Clearer" 
@@ -12,7 +12,7 @@ RUN apt-get update;apt-get -y install curl openjdk-11-jdk-headless ;apt-get -y u
     mkdir -p /usr/local/openunison && \
     groupadd -r openunison -g 433 && \
     useradd -u 431 -r -g openunison -d /usr/local/openunison -s /sbin/nologin -c "OpenUnison Docker image user" openunison && \
-    curl https://nexus.tremolo.io/repository/releases/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
+    curl https://nexus.tremolo.io/repository/betas/com/tremolosecurity/unison/openunison-util/$OPENUNISON_VERSION/openunison-util-$OPENUNISON_VERSION.jar > /usr/local/openunison/openunison-utils.jar && \
     chown -R openunison:openunison /usr/local/openunison 
 
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 MAINTAINER Tremolo Security, Inc.  - Docker <docker@tremolosecurity.com>
 
 ENV JDK_VERSION=1.8.0 \
-    OPENUNISON_VERSION="1.0.21"
+    OPENUNISON_VERSION="1.0.30"
 
 LABEL io.k8s.description="Job to clear dead letter queues" \
       io.k8s.display-name="OpenUnison Dead Letter Queue Clearer" 


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore